### PR TITLE
Fix model path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ mvn compile exec:java
 
 On startup the program checks for a speech model inside the `model` directory.
 If the model is missing it attempts to download
-`vosk-model-small-en-us-0.15.zip` and extract it. A progress bar is shown during
-the download.
+`vosk-model-small-en-us-0.15.zip` and extract it. The archive contains a
+subdirectory with the actual model files which the application now detects
+automatically. A progress bar is shown during the download.

--- a/src/main/java/com/example/TranscriberApp.java
+++ b/src/main/java/com/example/TranscriberApp.java
@@ -126,12 +126,26 @@ public class TranscriberApp extends JFrame {
         }
     }
 
+    private File locateModelPath(File dir) {
+        if (new File(dir, "am").exists()) {
+            return dir;
+        }
+        File[] subDirs = dir.listFiles(File::isDirectory);
+        if (subDirs != null && subDirs.length == 1) {
+            File candidate = subDirs[0];
+            if (new File(candidate, "am").exists()) {
+                return candidate;
+            }
+        }
+        return dir;
+    }
+
     private void startRecognition() {
         if (!modelReady || running) {
             return;
         }
         recognitionThread = new Thread(() -> {
-            try (Model model = new Model(modelDir.getAbsolutePath());
+            try (Model model = new Model(locateModelPath(modelDir).getAbsolutePath());
                  FileWriter writer = new FileWriter(outputFile, true)) {
                 Recognizer recognizer = new Recognizer(model, 16000.0f);
                 AudioFormat format = new AudioFormat(16000.0f, 16, 1, true, false);


### PR DESCRIPTION
## Summary
- handle extracted model subdirectory
- document detection of subdirectory in README

## Testing
- `mvn -q -DskipTests=true package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_6880b1ac0190832daf720591fc357f35