### PR TITLE
Allow selecting and downloading speech models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ The project is built with Maven. To run the UI:
 mvn compile exec:java
 ```
 
-On startup the program checks for a speech model inside the `model` directory.
-If the model is missing it attempts to download
-`vosk-model-small-en-us-0.15.zip` and extract it. The archive contains a
-subdirectory with the actual model files which the application now detects
-automatically. A progress bar is shown during the download.
+When launched, the UI shows a drop down of a few demo models. The selected
+model is stored under the `models` directory. If the chosen model is not
+present it is downloaded automatically and extracted. A progress bar indicates
+the download state.


### PR DESCRIPTION
## Summary
- add dropdown for choosing VOSK models
- download the selected model to `models/` if missing
- update README with instructions

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6882234dea94832db5430cdb9823dc13