### PR TITLE
Prevent using incomplete model downloads

### DIFF
--- a/src/main/java/com/example/TranscriberApp.java
+++ b/src/main/java/com/example/TranscriberApp.java
@@ -100,7 +100,7 @@ public class TranscriberApp extends JFrame {
         }
         ModelInfo info = models.get(sel);
         currentModelDir = new File(modelsBaseDir, info.dirName);
-        if (!currentModelDir.exists()) {
+        if (!isModelValid(currentModelDir)) {
             progressBar.setVisible(true);
             modelReady = false;
             updateStartButtonState();
@@ -139,13 +139,13 @@ public class TranscriberApp extends JFrame {
                 @Override
                 protected void done() {
                     progressBar.setVisible(false);
-                    modelReady = true;
+                    modelReady = isModelValid(currentModelDir);
                     updateStartButtonState();
                 }
             };
             worker.execute();
         } else {
-            modelReady = true;
+            modelReady = isModelValid(currentModelDir);
             updateStartButtonState();
         }
     }
@@ -185,6 +185,11 @@ public class TranscriberApp extends JFrame {
             }
         }
         return dir;
+    }
+
+    private boolean isModelValid(File dir) {
+        File path = locateModelPath(dir);
+        return new File(path, "am").exists();
     }
 
     private void loadInputDevices() {


### PR DESCRIPTION
## Summary
- verify that a Vosk model contains an `am` directory before marking it ready
- reuse this validity check when loading an existing model or after downloading

## Testing
- `mvn -q -e -DskipTests compile` *(fails: maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68822fd030d8832d9093a08334f0cda3