### PR TITLE
Add JavaFX vos-tts demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 # vos-stt
 
-This project demonstrates a simple Java Swing application that performs live
-speech transcription using the [VOSK](https://alphacephei.com/vosk/) library.
-The application listens to the default system audio device and appends
-recognized speech to `transcript.txt`. While running it shows the current
-partial transcription and a small volume bar so you can see that the microphone
-is active.
+This project now provides a minimal JavaFX application called **vos-tts** that
+shows live speech transcription in a compact window. The transcription is
+generated using a mocked service for demonstration purposes and appended to a
+session file.
 
 ## Usage
 
-The project is built with Maven. To run the UI:
+Launch the JavaFX UI with:
 
 ```bash
 mvn compile exec:java
 ```
 
-When launched, the UI shows a drop down of a few demo models. The selected
-model is stored under the `models` directory. If the chosen model is not
-present it is downloaded automatically and extracted. A progress bar indicates
-the download state.
+Click **Start Live Transcription** to begin a session. Lines of text will
+appear in large font as the mock recogniser generates them. A file named after
+the session timestamp is written to disk.

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
-    <artifactId>vosk-swing</artifactId>
+    <artifactId>vos-tts</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -18,6 +18,16 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20210307</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>21</version>
         </dependency>
     </dependencies>
     <build>
@@ -32,7 +42,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <mainClass>com.example.TranscriberApp</mainClass>
+                    <mainClass>com.example.vostts.VosTtsApp</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -1,0 +1,25 @@
+package com.example.vostts;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.Parent;
+import javafx.stage.Stage;
+
+public class VosTtsApp extends Application {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/example/vostts/app.fxml"));
+        Parent root = loader.load();
+        Scene scene = new Scene(root, 400, 300);
+        scene.getStylesheets().add(getClass().getResource("/com/example/vostts/light.css").toExternalForm());
+        stage.setTitle("vos-tts");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -1,0 +1,122 @@
+package com.example.vostts;
+
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.layout.VBox;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class VosTtsController {
+    @FXML private Label sessionLabel;
+    @FXML private Button startButton;
+    @FXML private Button pauseButton;
+    @FXML private VBox transcriptBox;
+    @FXML private ComboBox<String> exportCombo;
+
+    private final Deque<Label> lines = new ArrayDeque<>();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private Future<?> transcriptionTask;
+    private boolean running = false;
+    private BufferedWriter writer;
+
+    @FXML
+    private void initialize() {
+        exportCombo.getItems().addAll("TXT", "DOCX", "SRT");
+        updateSession("-");
+    }
+
+    @FXML
+    private void onStart() {
+        if (running) {
+            stopTranscription();
+        } else {
+            startTranscription();
+        }
+    }
+
+    @FXML
+    private void onPause() {
+        running = !running;
+        pauseButton.setText(running ? "Pause" : "Resume");
+    }
+
+    private void startTranscription() {
+        updateSession(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")));
+        startButton.setText("Stop");
+        pauseButton.setDisable(false);
+        running = true;
+        try {
+            writer = new BufferedWriter(new FileWriter("transcript_" + sessionLabel.getText() + ".txt"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        transcriptionTask = executor.submit(this::mockTranscription);
+    }
+
+    private void stopTranscription() {
+        running = false;
+        if (transcriptionTask != null) {
+            transcriptionTask.cancel(true);
+        }
+        try {
+            if (writer != null) {
+                writer.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        startButton.setText("Start Live Transcription");
+        pauseButton.setDisable(true);
+    }
+
+    private void updateSession(String id) {
+        sessionLabel.setText("Session: " + id);
+    }
+
+    private void mockTranscription() {
+        int count = 0;
+        while (!Thread.currentThread().isInterrupted()) {
+            if (running) {
+                String text = "Line " + (++count);
+                writeLine(text);
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void writeLine(String text) {
+        Platform.runLater(() -> {
+            Label line = new Label(text);
+            line.setStyle("-fx-font-size: 16pt; -fx-font-weight: bold;");
+            transcriptBox.getChildren().add(line);
+            lines.addLast(line);
+            if (lines.size() > 3) {
+                Label old = lines.removeFirst();
+                transcriptBox.getChildren().remove(old);
+            }
+        });
+        if (writer != null) {
+            try {
+                writer.write(text);
+                writer.newLine();
+                writer.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/resources/com/example/vostts/app.fxml
+++ b/src/main/resources/com/example/vostts/app.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.VosTtsController">
+    <top>
+        <VBox spacing="4" alignment="CENTER">
+            <Label fx:id="titleLabel" text="vos-tts" styleClass="title"/>
+            <Label fx:id="sessionLabel" text="Session: -"/>
+        </VBox>
+    </top>
+    <center>
+        <VBox spacing="8" alignment="CENTER">
+            <Button fx:id="startButton" text="Start Live Transcription" maxWidth="Infinity" onAction="#onStart" />
+            <VBox fx:id="transcriptBox" prefHeight="200" spacing="2" />
+        </VBox>
+    </center>
+    <bottom>
+        <HBox spacing="8" alignment="CENTER_LEFT" styleClass="bottom-bar">
+            <Button fx:id="pauseButton" text="Pause" disable="true" onAction="#onPause" />
+            <TextField fx:id="searchField" promptText="Search" HBox.hgrow="ALWAYS" />
+            <Button fx:id="saveButton" text="Save" />
+            <ComboBox fx:id="exportCombo" promptText="Export" />
+        </HBox>
+    </bottom>
+</BorderPane>

--- a/src/main/resources/com/example/vostts/dark.css
+++ b/src/main/resources/com/example/vostts/dark.css
@@ -1,0 +1,14 @@
+.root {
+    -fx-base: #2b2b2b;
+    -fx-text-fill: #f0f0f0;
+    --bg-color: #2b2b2b;
+    --text-color: #f0f0f0;
+}
+.title {
+    -fx-font-size: 20pt;
+    -fx-font-weight: bold;
+}
+.bottom-bar {
+    -fx-padding: 4 8 4 8;
+    -fx-background-color: linear-gradient(to top, #3a3a3a, #2b2b2b);
+}

--- a/src/main/resources/com/example/vostts/light.css
+++ b/src/main/resources/com/example/vostts/light.css
@@ -1,0 +1,14 @@
+.root {
+    -fx-base: white;
+    -fx-text-fill: black;
+    --bg-color: #ffffff;
+    --text-color: #000000;
+}
+.title {
+    -fx-font-size: 20pt;
+    -fx-font-weight: bold;
+}
+.bottom-bar {
+    -fx-padding: 4 8 4 8;
+    -fx-background-color: linear-gradient(to top, #e0e0e0, #f8f8f8);
+}


### PR DESCRIPTION
## Summary
- switch artifact to `vos-tts` and target Java 21
- add JavaFX dependencies and update run configuration
- implement `VosTtsApp` and `VosTtsController` with FXML UI
- provide light and dark CSS themes
- document running the new demo in the README

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68823ff4c29c832dbd07f21aa8b19528