### PR TITLE
Add JavaFX transcript browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ mvn compile exec:java
 Click **Start Live Transcription** to begin a session. Lines of text will
 appear in large font as the mock recogniser generates them. A file named after
 the session timestamp is written to disk.
+
+Use **🗂 Browse Sessions** to open the new Transcription Browser. From there you
+can open previous transcripts in a modal viewer or remove old sessions.

--- a/src/main/java/com/example/vostts/SessionMetadata.java
+++ b/src/main/java/com/example/vostts/SessionMetadata.java
@@ -1,0 +1,71 @@
+package com.example.vostts;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/** Model representing a stored transcription session. */
+public class SessionMetadata {
+    private final String name;
+    private final String date;
+    private final String duration;
+    private final String status;
+    private final Path directory;
+
+    public SessionMetadata(String name, String date, String duration, String status, Path directory) {
+        this.name = name;
+        this.date = date;
+        this.duration = duration;
+        this.status = status;
+        this.directory = directory;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Path getDirectory() {
+        return directory;
+    }
+
+    /**
+     * Load session metadata from the given session directory.
+     */
+    public static SessionMetadata load(Path dir) throws IOException {
+        Path metaFile = dir.resolve("metadata.json");
+        String name = dir.getFileName().toString();
+        String date = "";
+        String duration = "";
+        String status = "";
+        if (Files.exists(metaFile)) {
+            String json = Files.readString(metaFile);
+            JSONObject obj = new JSONObject(json);
+            name = obj.optString("name", name);
+            date = obj.optString("date", date);
+            duration = obj.optString("duration", duration);
+            status = obj.optString("status", status);
+        }
+        // fallback formatting if date missing
+        if (date.isEmpty()) {
+            LocalDateTime time = LocalDateTime.ofInstant(Files.getLastModifiedTime(dir).toInstant(), java.time.ZoneId.systemDefault());
+            date = time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        }
+        return new SessionMetadata(name, date, duration, status, dir);
+    }
+}

--- a/src/main/java/com/example/vostts/TranscriptViewerController.java
+++ b/src/main/java/com/example/vostts/TranscriptViewerController.java
@@ -1,0 +1,46 @@
+package com.example.vostts;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Controller for the modal transcript viewer. */
+public class TranscriptViewerController {
+    @FXML private Label nameLabel;
+    @FXML private Label dateLabel;
+    @FXML private TextArea textArea;
+    @FXML private Button closeButton;
+
+    private SessionMetadata session;
+
+    public void loadSession(SessionMetadata session) {
+        this.session = session;
+        nameLabel.setText(session.getName());
+        dateLabel.setText(session.getDate());
+        Path file = session.getDirectory().resolve("transcript.txt");
+        try {
+            String content = Files.exists(file) ? Files.readString(file) : "";
+            textArea.setText(content);
+        } catch (IOException e) {
+            showError("Failed to load transcript: " + e.getMessage());
+        }
+    }
+
+    @FXML
+    private void onClose() {
+        Stage stage = (Stage) closeButton.getScene().getWindow();
+        stage.close();
+    }
+
+    private void showError(String msg) {
+        Alert alert = new Alert(Alert.AlertType.ERROR, msg, javafx.scene.control.ButtonType.OK);
+        alert.showAndWait();
+    }
+}

--- a/src/main/java/com/example/vostts/TranscriptionBrowserController.java
+++ b/src/main/java/com/example/vostts/TranscriptionBrowserController.java
@@ -1,0 +1,118 @@
+package com.example.vostts;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.Parent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Controller for the Transcription Browser window. */
+public class TranscriptionBrowserController {
+    @FXML private TableView<SessionMetadata> table;
+    @FXML private TableColumn<SessionMetadata, String> nameColumn;
+    @FXML private TableColumn<SessionMetadata, String> dateColumn;
+    @FXML private TableColumn<SessionMetadata, String> durationColumn;
+    @FXML private TableColumn<SessionMetadata, String> statusColumn;
+
+    private final ObservableList<SessionMetadata> sessions = FXCollections.observableArrayList();
+
+    @FXML
+    private void initialize() {
+        nameColumn.setCellValueFactory(new PropertyValueFactory<>("name"));
+        dateColumn.setCellValueFactory(new PropertyValueFactory<>("date"));
+        durationColumn.setCellValueFactory(new PropertyValueFactory<>("duration"));
+        statusColumn.setCellValueFactory(new PropertyValueFactory<>("status"));
+        table.setItems(sessions);
+        refresh();
+    }
+
+    @FXML
+    private void onRefresh() {
+        refresh();
+    }
+
+    private void refresh() {
+        sessions.clear();
+        Path base = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions");
+        if (Files.isDirectory(base)) {
+            try {
+                List<SessionMetadata> list = Files.list(base)
+                        .filter(Files::isDirectory)
+                        .map(p -> {
+                            try {
+                                return SessionMetadata.load(p);
+                            } catch (IOException e) {
+                                return null;
+                            }
+                        })
+                        .filter(m -> m != null)
+                        .collect(Collectors.toList());
+                sessions.addAll(list);
+            } catch (IOException e) {
+                showError("Failed to read sessions: " + e.getMessage());
+            }
+        }
+    }
+
+    @FXML
+    private void onOpen() {
+        SessionMetadata selected = table.getSelectionModel().getSelectedItem();
+        if (selected == null) return;
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/example/vostts/viewer.fxml"));
+            Parent root = loader.load();
+            TranscriptViewerController controller = loader.getController();
+            controller.loadSession(selected);
+            Stage stage = new Stage();
+            stage.initModality(Modality.APPLICATION_MODAL);
+            stage.setTitle("Transcript Viewer");
+            Scene scene = new Scene(root, 600, 400);
+            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            stage.setScene(scene);
+            stage.showAndWait();
+        } catch (IOException e) {
+            showError("Failed to open session: " + e.getMessage());
+        }
+    }
+
+    @FXML
+    private void onDelete() {
+        SessionMetadata selected = table.getSelectionModel().getSelectedItem();
+        if (selected == null) return;
+        try {
+            Files.walk(selected.getDirectory())
+                .sorted((a, b) -> b.compareTo(a))
+                .forEach(p -> {
+                    try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                });
+            refresh();
+        } catch (IOException e) {
+            showError("Failed to delete session: " + e.getMessage());
+        }
+    }
+
+    @FXML
+    private void onExport() {
+        // Placeholder: real export not implemented
+        showError("Export not implemented in demo.");
+    }
+
+    private void showError(String msg) {
+        Alert alert = new Alert(Alert.AlertType.ERROR, msg, javafx.scene.control.ButtonType.OK);
+        alert.showAndWait();
+    }
+}

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -33,7 +33,7 @@ public class VosTtsApp extends Application {
             LOG.info("Speech model found");
             controller.setModelReady(true);
             Scene scene = new Scene(root, 400, 300);
-            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/light.css").toExternalForm());
+            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
             stage.setTitle("vos-tts");
             stage.setScene(scene);
             stage.show();
@@ -54,7 +54,7 @@ public class VosTtsApp extends Application {
                 controller.setModelReady(true);
                 LOG.info("Speech model ready");
                 Scene scene = new Scene(root, 400, 300);
-                scene.getStylesheets().add(getClass().getResource("/com/example/vostts/light.css").toExternalForm());
+                scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
                 stage.setScene(scene);
             });
             new Thread(task).start();

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -7,6 +7,9 @@ import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.stage.Modality;
 
 import org.vosk.Model;
 import org.vosk.Recognizer;
@@ -36,6 +39,8 @@ public class VosTtsController {
     @FXML private Button pauseButton;
     @FXML private VBox transcriptBox;
     @FXML private ComboBox<Mixer.Info> deviceCombo;
+    
+    private Stage browserStage;
 
     private final Deque<Label> lines = new ArrayDeque<>();
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -69,6 +74,28 @@ public class VosTtsController {
         running = !running;
         LOG.fine(() -> "Paused state: " + !running);
         pauseButton.setText(running ? "Pause" : "Resume");
+    }
+
+    @FXML
+    private void onBrowse() {
+        if (browserStage != null && browserStage.isShowing()) {
+            browserStage.requestFocus();
+            return;
+        }
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/example/vostts/browser.fxml"));
+            Parent root = loader.load();
+            browserStage = new Stage();
+            browserStage.initModality(Modality.NONE);
+            browserStage.setTitle("Transcription Browser");
+            Scene scene = new Scene(root, 600, 450);
+            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            browserStage.setScene(scene);
+            browserStage.show();
+        } catch (IOException e) {
+            Alert alert = new Alert(Alert.AlertType.ERROR, "Failed to open browser: " + e.getMessage(), ButtonType.OK);
+            alert.showAndWait();
+        }
     }
 
     private void startTranscription() {

--- a/src/main/resources/com/example/vostts/app.fxml
+++ b/src/main/resources/com/example/vostts/app.fxml
@@ -18,6 +18,7 @@
         <HBox spacing="8" alignment="CENTER_LEFT" styleClass="bottom-bar">
             <Button fx:id="pauseButton" text="Pause" disable="true" onAction="#onPause" />
             <ComboBox fx:id="deviceCombo" promptText="Audio Input" />
+            <Button text="🗂 Browse Sessions" onAction="#onBrowse" />
         </HBox>
     </bottom>
 </BorderPane>

--- a/src/main/resources/com/example/vostts/browser.fxml
+++ b/src/main/resources/com/example/vostts/browser.fxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptionBrowserController">
+    <top>
+        <Label text="Transcription Browser" styleClass="title" BorderPane.alignment="CENTER" />
+    </top>
+    <center>
+        <TableView fx:id="table" prefHeight="400">
+            <columns>
+                <TableColumn fx:id="nameColumn" text="Name" prefWidth="200" />
+                <TableColumn fx:id="dateColumn" text="Date" prefWidth="180" />
+                <TableColumn fx:id="durationColumn" text="Duration" prefWidth="120" />
+                <TableColumn fx:id="statusColumn" text="Status" prefWidth="120" />
+            </columns>
+        </TableView>
+    </center>
+    <bottom>
+        <HBox spacing="8" alignment="CENTER_RIGHT" styleClass="bottom-bar">
+            <Button text="Open" onAction="#onOpen" />
+            <Button text="Delete" onAction="#onDelete" />
+            <Button text="Export" onAction="#onExport" />
+            <Button text="Refresh" onAction="#onRefresh" />
+        </HBox>
+    </bottom>
+</BorderPane>

--- a/src/main/resources/com/example/vostts/dark.css
+++ b/src/main/resources/com/example/vostts/dark.css
@@ -1,12 +1,29 @@
 .root {
-    -fx-base: #2b2b2b;
-    -fx-text-fill: #f0f0f0;
+    -fx-base: #1E1E1E;
+    -fx-background: #1E1E1E;
+    -fx-text-fill: #EEEEEE;
 }
+
+.button {
+    -fx-background-color: #333333;
+    -fx-text-fill: #EEEEEE;
+}
+
+.button:hover {
+    -fx-background-color: #555555;
+}
+
 .title {
     -fx-font-size: 20pt;
     -fx-font-weight: bold;
 }
+
 .bottom-bar {
     -fx-padding: 4 8 4 8;
-    -fx-background-color: linear-gradient(to top, #3a3a3a, #2b2b2b);
+    -fx-background-color: #333333;
+}
+
+.table-view {
+    -fx-control-inner-background: #1E1E1E;
+    -fx-text-fill: #EEEEEE;
 }

--- a/src/main/resources/com/example/vostts/viewer.fxml
+++ b/src/main/resources/com/example/vostts/viewer.fxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptViewerController">
+    <top>
+        <VBox spacing="4" alignment="CENTER">
+            <Label fx:id="nameLabel" styleClass="title" />
+            <Label fx:id="dateLabel" />
+        </VBox>
+    </top>
+    <center>
+        <TextArea fx:id="textArea" editable="false" wrapText="true" />
+    </center>
+    <bottom>
+        <HBox alignment="CENTER_RIGHT" styleClass="bottom-bar">
+            <Button text="Close" onAction="#onClose" />
+        </HBox>
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Summary
- make dark theme the default
- add a new `TranscriptionBrowser` window with a table of saved sessions
- add modal `TranscriptViewer` window to read individual transcripts
- hook up **🗂 Browse Sessions** button in the main UI
- document new feature in README

## Testing
- `mvn -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688302f7f1d0832dbbd780fa68dc1733