### PR TITLE
Improve model download UX and fix model path

### DIFF
--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -7,6 +7,7 @@ import javafx.scene.Parent;
 import javafx.stage.Stage;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
+import javafx.stage.StageStyle;
 import javafx.scene.layout.VBox;
 import javafx.concurrent.Task;
 
@@ -41,21 +42,28 @@ public class VosTtsApp extends Application {
             LOG.info("Speech model not present, downloading...");
             ProgressBar bar = new ProgressBar(0);
             Label label = new Label("Downloading speech model...\nThis may take a few minutes.");
-            VBox box = new VBox(10, label, bar);
+            Label speedLabel = new Label();
+            VBox box = new VBox(10, label, bar, speedLabel);
             box.setStyle("-fx-padding: 20; -fx-alignment: center;");
-            Scene splashScene = new Scene(box, 400, 150);
-            stage.setScene(splashScene);
-            stage.setTitle("Preparing Model");
-            stage.show();
+            Scene splashScene = new Scene(box, 400, 170);
+
+            Stage splashStage = new Stage(StageStyle.UNDECORATED);
+            splashStage.setTitle("Preparing Model");
+            splashStage.setScene(splashScene);
+            splashStage.show();
 
             Task<Void> task = controller.createModelDownloadTask(modelDir);
             bar.progressProperty().bind(task.progressProperty());
+            speedLabel.textProperty().bind(task.messageProperty());
             task.setOnSucceeded(e -> {
+                controller.setModelDir(modelDir);
                 controller.setModelReady(true);
                 LOG.info("Speech model ready");
                 Scene scene = new Scene(root, 400, 300);
                 scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+                splashStage.close();
                 stage.setScene(scene);
+                stage.show();
             });
             new Thread(task).start();
         }


### PR DESCRIPTION
## Summary
- show download speed in MB/s on the splash screen
- use an undecorated stage for the splash screen
- validate the extracted model and resolve the actual model directory
- track splash-screen download progress with a bound label

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68832df806a0832dbf4183c31aaa6db9