### PR TITLE
Update transcription UI

### DIFF
--- a/src/main/resources/com/example/vostts/app.fxml
+++ b/src/main/resources/com/example/vostts/app.fxml
@@ -11,13 +11,12 @@
     <center>
         <VBox spacing="8" alignment="CENTER">
             <Button fx:id="startButton" text="Start Live Transcription" maxWidth="Infinity" onAction="#onStart" />
-            <Label fx:id="partialLabel" text="" styleClass="partial" />
-            <VBox fx:id="transcriptBox" prefHeight="200" spacing="2" />
+            <Label fx:id="partialLabel" text="" styleClass="partial" alignment="CENTER" />
+            <VBox fx:id="transcriptBox" prefHeight="200" spacing="2" alignment="CENTER" />
         </VBox>
     </center>
     <bottom>
         <HBox spacing="8" alignment="CENTER_LEFT" styleClass="bottom-bar">
-            <Button fx:id="pauseButton" text="Pause" disable="true" onAction="#onPause" />
             <ComboBox fx:id="deviceCombo" promptText="Audio Input" />
             <Button text="🗂 Browse Sessions" onAction="#onBrowse" />
         </HBox>


### PR DESCRIPTION
## Summary
- center live transcription text
- remove pause button from UI and controller
- disable audio device selection while transcription is running
- save transcripts into the session browser folder

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6883443472a4832db86cdc9d6353a1b8