### PR TITLE
Add undecorated windows and settings window

### DIFF
--- a/src/main/java/com/example/vostts/SettingsController.java
+++ b/src/main/java/com/example/vostts/SettingsController.java
@@ -1,0 +1,53 @@
+package com.example.vostts;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+import javax.sound.sampled.Mixer;
+
+/** Controller for the settings window. */
+public class SettingsController {
+    @FXML private TextField wrapField;
+    @FXML private TextField timeoutField;
+    @FXML private ComboBox<Mixer.Info> deviceCombo;
+    @FXML private Button closeButton;
+
+    private VosTtsController parent;
+
+    public void setParent(VosTtsController controller) {
+        this.parent = controller;
+        wrapField.setText(Integer.toString(controller.getWrapChars()));
+        timeoutField.setText(Integer.toString(controller.getTimeoutSeconds()));
+        deviceCombo.getItems().setAll(VosTtsController.listInputDevices());
+        Mixer.Info sel = controller.getSelectedDevice();
+        if (sel != null) {
+            deviceCombo.getSelectionModel().select(sel);
+        } else if (!deviceCombo.getItems().isEmpty()) {
+            deviceCombo.getSelectionModel().selectFirst();
+        }
+    }
+
+    @FXML
+    private void onSave() {
+        try {
+            int wrap = Integer.parseInt(wrapField.getText().trim());
+            parent.setWrapChars(wrap);
+        } catch (NumberFormatException ignored) {}
+        try {
+            int t = Integer.parseInt(timeoutField.getText().trim());
+            parent.setTimeoutSeconds(t);
+        } catch (NumberFormatException ignored) {}
+        Mixer.Info sel = deviceCombo.getSelectionModel().getSelectedItem();
+        parent.setSelectedDevice(sel);
+        onClose();
+    }
+
+    @FXML
+    private void onClose() {
+        Stage stage = (Stage) closeButton.getScene().getWindow();
+        stage.close();
+    }
+}

--- a/src/main/java/com/example/vostts/TranscriptionBrowserController.java
+++ b/src/main/java/com/example/vostts/TranscriptionBrowserController.java
@@ -9,6 +9,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.Parent;
@@ -79,7 +80,7 @@ public class TranscriptionBrowserController {
             controller.loadSession(selected);
             Stage stage = new Stage();
             stage.initModality(Modality.APPLICATION_MODAL);
-            stage.setTitle("Transcript Viewer");
+            stage.initStyle(StageStyle.UNDECORATED);
             Scene scene = new Scene(root, 600, 400);
             scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
             stage.setScene(scene);
@@ -109,6 +110,12 @@ public class TranscriptionBrowserController {
     private void onExport() {
         // Placeholder: real export not implemented
         showError("Export not implemented in demo.");
+    }
+
+    @FXML
+    private void onClose() {
+        Stage stage = (Stage) table.getScene().getWindow();
+        stage.close();
     }
 
     private void showError(String msg) {

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -30,12 +30,13 @@ public class VosTtsApp extends Application {
         controller.setModelDir(modelDir);
         LOG.fine(() -> "Using model directory: " + modelDir.getAbsolutePath());
 
+        stage.initStyle(StageStyle.UNDECORATED);
+
         if (VosTtsController.isModelValid(modelDir)) {
             LOG.info("Speech model found");
             controller.setModelReady(true);
             Scene scene = new Scene(root, 400, 300);
             scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
-            stage.setTitle("vos-tts");
             stage.setScene(scene);
             stage.show();
         } else {

--- a/src/main/resources/com/example/vostts/app.fxml
+++ b/src/main/resources/com/example/vostts/app.fxml
@@ -10,8 +10,9 @@
             <right>
                 <HBox spacing="8" alignment="CENTER_RIGHT">
                     <Button text="📁" onAction="#onBrowse" styleClass="icon-button" />
-                    <Button text="⚙" onAction="#onSettings" styleClass="icon-button" />
+                    <Button fx:id="settingsButton" text="⚙" onAction="#onSettings" styleClass="icon-button" />
                     <Button text="🌗" onAction="#onToggleTheme" styleClass="icon-button" />
+                    <Button text="✕" onAction="#onCloseApp" styleClass="icon-button close-button" />
                 </HBox>
             </right>
         </BorderPane>
@@ -25,9 +26,6 @@
     <bottom>
         <HBox spacing="16" alignment="CENTER" styleClass="bottom-bar">
             <Button fx:id="startButton" text="Start" onAction="#onStart" styleClass="control-button" />
-            <Button fx:id="pauseButton" text="Paused" onAction="#onPauseResume" styleClass="control-button" />
-            <Button text="Save" onAction="#onSave" styleClass="control-button" />
-            <Button text="Timeout" onAction="#onAutoStop" styleClass="control-button" />
         </HBox>
     </bottom>
 </BorderPane>

--- a/src/main/resources/com/example/vostts/browser.fxml
+++ b/src/main/resources/com/example/vostts/browser.fxml
@@ -3,7 +3,14 @@
 <?import javafx.scene.layout.*?>
 <BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptionBrowserController">
     <top>
-        <Label text="Transcription Browser" styleClass="title" BorderPane.alignment="CENTER" />
+        <BorderPane styleClass="top-bar">
+            <center>
+                <Label text="Transcription Browser" styleClass="title" />
+            </center>
+            <right>
+                <Button text="✕" onAction="#onClose" styleClass="icon-button close-button" />
+            </right>
+        </BorderPane>
     </top>
     <center>
         <TableView fx:id="table" prefHeight="400">

--- a/src/main/resources/com/example/vostts/dark.css
+++ b/src/main/resources/com/example/vostts/dark.css
@@ -31,6 +31,14 @@
     -fx-background-color: #2A2A2A;
 }
 
+.close-button {
+    -fx-text-fill: #FF6666;
+}
+
+.close-button:hover {
+    -fx-background-color: #AA2222;
+}
+
 .control-button {
     -fx-background-color: transparent;
     -fx-text-fill: #EEEEEE;

--- a/src/main/resources/com/example/vostts/light.css
+++ b/src/main/resources/com/example/vostts/light.css
@@ -29,6 +29,14 @@
     -fx-background-color: #dddddd;
 }
 
+.close-button {
+    -fx-text-fill: #aa0000;
+}
+
+.close-button:hover {
+    -fx-background-color: #ffcccc;
+}
+
 .control-button {
     -fx-background-color: transparent;
 }

--- a/src/main/resources/com/example/vostts/settings.fxml
+++ b/src/main/resources/com/example/vostts/settings.fxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" spacing="10" alignment="CENTER" fx:controller="com.example.vostts.SettingsController" styleClass="root-pane">
+    <HBox spacing="8" alignment="CENTER_LEFT">
+        <Label text="Wrap length:" />
+        <TextField fx:id="wrapField" prefWidth="80" />
+    </HBox>
+    <HBox spacing="8" alignment="CENTER_LEFT">
+        <Label text="Timeout (s):" />
+        <TextField fx:id="timeoutField" prefWidth="80" />
+    </HBox>
+    <HBox spacing="8" alignment="CENTER_LEFT">
+        <Label text="Input device:" />
+        <ComboBox fx:id="deviceCombo" prefWidth="180" />
+    </HBox>
+    <HBox spacing="8" alignment="CENTER_RIGHT">
+        <Button text="Save" onAction="#onSave" />
+        <Button fx:id="closeButton" text="Close" onAction="#onClose" />
+    </HBox>
+</VBox>

--- a/src/main/resources/com/example/vostts/viewer.fxml
+++ b/src/main/resources/com/example/vostts/viewer.fxml
@@ -3,17 +3,24 @@
 <?import javafx.scene.layout.*?>
 <BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptViewerController">
     <top>
-        <VBox spacing="4" alignment="CENTER">
-            <Label fx:id="nameLabel" styleClass="title" />
-            <Label fx:id="dateLabel" />
-        </VBox>
+        <BorderPane styleClass="top-bar">
+            <center>
+                <VBox spacing="4" alignment="CENTER">
+                    <Label fx:id="nameLabel" styleClass="title" />
+                    <Label fx:id="dateLabel" />
+                </VBox>
+            </center>
+            <right>
+                <Button text="✕" onAction="#onClose" styleClass="icon-button close-button" />
+            </right>
+        </BorderPane>
     </top>
     <center>
         <TextArea fx:id="textArea" editable="false" wrapText="true" />
     </center>
     <bottom>
         <HBox alignment="CENTER_RIGHT" styleClass="bottom-bar">
-            <Button fx:id="closeButton" text="Close" onAction="#onClose" />
+            <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="close-button" />
         </HBox>
     </bottom>
 </BorderPane>


### PR DESCRIPTION
## Summary
- make all stages undecorated and provide custom close buttons
- move wrap length and new timeout plus device selection into a settings window
- disable settings while transcription runs
- remove pause/save UI controls

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5705360832da0a8182b8f376e9e