### PR TITLE
Add global theme support and draggable windows

### DIFF
--- a/src/main/java/com/example/vostts/DragUtil.java
+++ b/src/main/java/com/example/vostts/DragUtil.java
@@ -1,0 +1,24 @@
+package com.example.vostts;
+
+import javafx.scene.Node;
+import javafx.stage.Stage;
+
+/** Simple helper to make undecorated stages draggable. */
+public final class DragUtil {
+    private DragUtil() {}
+
+    /**
+     * Make the specified node act as a drag handle for moving the stage.
+     */
+    public static void makeDraggable(Stage stage, Node node) {
+        final double[] offset = new double[2];
+        node.setOnMousePressed(e -> {
+            offset[0] = e.getSceneX();
+            offset[1] = e.getSceneY();
+        });
+        node.setOnMouseDragged(e -> {
+            stage.setX(e.getScreenX() - offset[0]);
+            stage.setY(e.getScreenY() - offset[1]);
+        });
+    }
+}

--- a/src/main/java/com/example/vostts/ThemeManager.java
+++ b/src/main/java/com/example/vostts/ThemeManager.java
@@ -1,0 +1,29 @@
+package com.example.vostts;
+
+import javafx.scene.Scene;
+
+/** Utility class to manage global UI theme. */
+public final class ThemeManager {
+    private static boolean darkMode = true;
+
+    private ThemeManager() {}
+
+    /** Return true if the dark theme is active. */
+    public static boolean isDarkMode() {
+        return darkMode;
+    }
+
+    /** Toggle between dark and light themes. */
+    public static void toggle() {
+        darkMode = !darkMode;
+    }
+
+    /** Apply the current theme stylesheets to the given scene. */
+    public static void apply(Scene scene) {
+        if (scene == null) return;
+        String dark = ThemeManager.class.getResource("/com/example/vostts/dark.css").toExternalForm();
+        String light = ThemeManager.class.getResource("/com/example/vostts/light.css").toExternalForm();
+        scene.getStylesheets().removeAll(dark, light);
+        scene.getStylesheets().add(darkMode ? dark : light);
+    }
+}

--- a/src/main/java/com/example/vostts/TranscriptionBrowserController.java
+++ b/src/main/java/com/example/vostts/TranscriptionBrowserController.java
@@ -14,6 +14,9 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.Parent;
 
+import com.example.vostts.ThemeManager;
+import com.example.vostts.DragUtil;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -82,7 +85,8 @@ public class TranscriptionBrowserController {
             stage.initModality(Modality.APPLICATION_MODAL);
             stage.initStyle(StageStyle.UNDECORATED);
             Scene scene = new Scene(root, 600, 400);
-            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            ThemeManager.apply(scene);
+            DragUtil.makeDraggable(stage, root);
             stage.setScene(scene);
             stage.showAndWait();
         } catch (IOException e) {

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -11,6 +11,10 @@ import javafx.stage.StageStyle;
 import javafx.scene.layout.VBox;
 import javafx.concurrent.Task;
 
+// Application utilities
+import com.example.vostts.ThemeManager;
+import com.example.vostts.DragUtil;
+
 import com.example.logging.LoggingConfig;
 
 import java.util.logging.Logger;
@@ -36,7 +40,8 @@ public class VosTtsApp extends Application {
             LOG.info("Speech model found");
             controller.setModelReady(true);
             Scene scene = new Scene(root, 400, 300);
-            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            ThemeManager.apply(scene);
+            DragUtil.makeDraggable(stage, root);
             stage.setScene(scene);
             stage.show();
         } else {
@@ -47,10 +52,12 @@ public class VosTtsApp extends Application {
             VBox box = new VBox(10, label, bar, speedLabel);
             box.setStyle("-fx-padding: 20; -fx-alignment: center;");
             Scene splashScene = new Scene(box, 400, 170);
+            ThemeManager.apply(splashScene);
 
             Stage splashStage = new Stage(StageStyle.UNDECORATED);
             splashStage.setTitle("Preparing Model");
             splashStage.setScene(splashScene);
+            DragUtil.makeDraggable(splashStage, box);
             splashStage.show();
 
             Task<Void> task = controller.createModelDownloadTask(modelDir);
@@ -61,7 +68,8 @@ public class VosTtsApp extends Application {
                 controller.setModelReady(true);
                 LOG.info("Speech model ready");
                 Scene scene = new Scene(root, 400, 300);
-                scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+                ThemeManager.apply(scene);
+                DragUtil.makeDraggable(stage, root);
                 splashStage.close();
                 stage.setScene(scene);
                 stage.show();

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -22,6 +22,8 @@ import org.vosk.Recognizer;
 import org.json.JSONObject;
 
 import com.example.vostts.SettingsController;
+import com.example.vostts.ThemeManager;
+import com.example.vostts.DragUtil;
 
 import javax.sound.sampled.*;
 import java.io.*;
@@ -69,7 +71,6 @@ public class VosTtsController {
     private long startTime;
     private long pauseAccum;
     private long pauseStarted;
-    private boolean darkMode = true;
     /** Maximum characters before inserting a line break. */
     private int wrapChars = 35;
 
@@ -113,7 +114,8 @@ public class VosTtsController {
             browserStage.initModality(Modality.NONE);
             browserStage.initStyle(StageStyle.UNDECORATED);
             Scene scene = new Scene(root, 600, 450);
-            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            ThemeManager.apply(scene);
+            DragUtil.makeDraggable(browserStage, root);
             browserStage.setScene(scene);
             browserStage.show();
         } catch (IOException e) {
@@ -133,7 +135,8 @@ public class VosTtsController {
             stage.initModality(Modality.APPLICATION_MODAL);
             stage.initStyle(StageStyle.UNDECORATED);
             Scene scene = new Scene(root, 300, 200);
-            scene.getStylesheets().add(getClass().getResource("/com/example/vostts/dark.css").toExternalForm());
+            ThemeManager.apply(scene);
+            DragUtil.makeDraggable(stage, root);
             stage.setScene(scene);
             stage.showAndWait();
         } catch (IOException e) {
@@ -152,18 +155,11 @@ public class VosTtsController {
 
     @FXML
     private void onToggleTheme() {
-        Scene scene = startButton.getScene();
-        if (scene == null) return;
-        String dark = getClass().getResource("/com/example/vostts/dark.css").toExternalForm();
-        String light = getClass().getResource("/com/example/vostts/light.css").toExternalForm();
-        if (darkMode) {
-            scene.getStylesheets().remove(dark);
-            scene.getStylesheets().add(light);
-        } else {
-            scene.getStylesheets().remove(light);
-            scene.getStylesheets().add(dark);
+        ThemeManager.toggle();
+        ThemeManager.apply(startButton.getScene());
+        if (browserStage != null && browserStage.isShowing()) {
+            ThemeManager.apply(browserStage.getScene());
         }
-        darkMode = !darkMode;
     }
 
     @FXML

--- a/src/main/resources/com/example/vostts/settings.fxml
+++ b/src/main/resources/com/example/vostts/settings.fxml
@@ -16,6 +16,6 @@
     </HBox>
     <HBox spacing="8" alignment="CENTER_RIGHT">
         <Button text="Save" onAction="#onSave" />
-        <Button fx:id="closeButton" text="Close" onAction="#onClose" />
+        <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="close-button" />
     </HBox>
 </VBox>


### PR DESCRIPTION
## Summary
- allow changing the theme for every window via new `ThemeManager`
- ensure undecorated stages are draggable with `DragUtil`
- open all auxiliary windows with the active theme
- style the settings close button to match the app

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6883e9dbd8f0832d9493f89141f20214