### PR TITLE
Store active transcript at app root

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Using the JavaFX plugin avoids warnings about an unsupported configuration when
 running the application.
 
 Click **Start Live Transcription** to begin a session. Lines of text will
-appear in large font as the mock recogniser generates them. Each session now
-writes a `transcript.srt` subtitle file with timestamps for every recognised
-phrase.
+appear in large font as the mock recogniser generates them. While a session is
+running the subtitle file `transcript.srt` is written to the application
+directory. Once the session ends the file is moved into a session folder under
+your home directory with timestamps for every recognised phrase.
 
 Use **🗂 Browse Sessions** to open the new Transcription Browser. From there you
 can open previous transcripts in a modal viewer or remove old sessions.

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -274,12 +274,11 @@ public class VosTtsController {
     }
 
     private void runRecognition() {
-        Path base = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions", currentSessionId);
-        base.toFile().mkdirs();
-        File outFile = base.resolve("transcript.srt").toFile();
-        LOG.fine(() -> "Writing transcript to " + outFile.getAbsolutePath());
+        Path sessionDir = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions", currentSessionId);
+        File activeFile = new File("transcript.srt");
+        LOG.fine(() -> "Writing transcript to " + activeFile.getAbsolutePath());
         try (Model model = new Model(locateModelPath(modelDir).getAbsolutePath());
-             BufferedWriter bw = new BufferedWriter(new FileWriter(outFile))) {
+             BufferedWriter bw = new BufferedWriter(new FileWriter(activeFile))) {
             writer = bw;
             Recognizer recognizer = new Recognizer(model, 16000.0f);
             AudioFormat format = new AudioFormat(16000.0f, 16, 1, true, false);
@@ -324,6 +323,14 @@ public class VosTtsController {
                     settingsButton.setDisable(false);
                 }
             });
+            // Move the transcript to the session directory when finished
+            try {
+                sessionDir.toFile().mkdirs();
+                Files.move(activeFile.toPath(), sessionDir.resolve("transcript.srt"),
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                LOG.log(Level.SEVERE, "Failed to store session transcript", e);
+            }
             // Ensure the writer reference is cleared after the session ends.
             writer = null;
             LOG.fine("Recognition loop finished");


### PR DESCRIPTION
## Summary
- keep the active `transcript.srt` in the application directory
- move the transcript to the session folder once a session ends
- document updated behaviour in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885428c5610832daf9ff3558323ee25