### PR TITLE
Add monitor page for processed transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ your home directory with timestamps for every recognised phrase.
 Use **🗂 Browse Sessions** to open the new Transcription Browser. From there you
 can open previous transcripts in a modal viewer or remove old sessions.
 
+Use **🗒 Processed Files** to open the monitor page showing which transcript
+files have already been processed.
+
 The settings menu now includes an option to control how many characters are
 displayed on a single transcription line before wrapping occurs. The default is
 35 characters.

--- a/src/main/java/com/example/vostts/MonitorController.java
+++ b/src/main/java/com/example/vostts/MonitorController.java
@@ -1,0 +1,58 @@
+package com.example.vostts;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Controller for the monitor window listing processed text files. */
+public class MonitorController {
+    @FXML
+    private ListView<String> listView;
+
+    @FXML
+    private void initialize() {
+        refresh();
+    }
+
+    @FXML
+    private void onRefresh() {
+        refresh();
+    }
+
+    @FXML
+    private void onClose() {
+        Stage stage = (Stage) listView.getScene().getWindow();
+        stage.close();
+    }
+
+    private void refresh() {
+        listView.getItems().clear();
+        Path base = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions");
+        if (Files.isDirectory(base)) {
+            try {
+                List<String> files = Files.list(base)
+                        .filter(Files::isDirectory)
+                        .map(p -> p.resolve("transcript.srt"))
+                        .filter(Files::exists)
+                        .map(Path::toString)
+                        .collect(Collectors.toList());
+                listView.getItems().addAll(files);
+            } catch (IOException e) {
+                showError("Failed to read sessions: " + e.getMessage());
+            }
+        }
+    }
+
+    private void showError(String msg) {
+        Alert alert = new Alert(Alert.AlertType.ERROR, msg, javafx.scene.control.ButtonType.OK);
+        alert.showAndWait();
+    }
+}

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -57,6 +57,7 @@ public class VosTtsController {
     private Timeline autoStop;
     
     private Stage browserStage;
+    private Stage monitorStage;
 
     private final Deque<Label> lines = new ArrayDeque<>();
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -124,6 +125,29 @@ public class VosTtsController {
             browserStage.show();
         } catch (IOException e) {
             Alert alert = new Alert(Alert.AlertType.ERROR, "Failed to open browser: " + e.getMessage(), ButtonType.OK);
+            alert.showAndWait();
+        }
+    }
+
+    @FXML
+    private void onMonitor() {
+        if (monitorStage != null && monitorStage.isShowing()) {
+            monitorStage.requestFocus();
+            return;
+        }
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/example/vostts/monitor.fxml"));
+            Parent root = loader.load();
+            monitorStage = new Stage();
+            monitorStage.initModality(Modality.NONE);
+            monitorStage.initStyle(StageStyle.UNDECORATED);
+            Scene scene = new Scene(root, 500, 400);
+            ThemeManager.apply(scene);
+            DragUtil.makeDraggable(monitorStage, root);
+            monitorStage.setScene(scene);
+            monitorStage.show();
+        } catch (IOException e) {
+            Alert alert = new Alert(Alert.AlertType.ERROR, "Failed to open monitor: " + e.getMessage(), ButtonType.OK);
             alert.showAndWait();
         }
     }

--- a/src/main/resources/com/example/vostts/app.fxml
+++ b/src/main/resources/com/example/vostts/app.fxml
@@ -10,6 +10,7 @@
             <right>
                 <HBox spacing="8" alignment="CENTER_RIGHT">
                     <Button text="📁" onAction="#onBrowse" styleClass="icon-button" />
+                    <Button text="🗒" onAction="#onMonitor" styleClass="icon-button" />
                     <Button fx:id="settingsButton" text="⚙" onAction="#onSettings" styleClass="icon-button" />
                     <Button text="🌗" onAction="#onToggleTheme" styleClass="icon-button" />
                     <Button text="✕" onAction="#onCloseApp" styleClass="icon-button close-button" />

--- a/src/main/resources/com/example/vostts/monitor.fxml
+++ b/src/main/resources/com/example/vostts/monitor.fxml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.MonitorController">
+    <top>
+        <BorderPane styleClass="top-bar">
+            <center>
+                <Label text="Processed Files" styleClass="title" />
+            </center>
+            <right>
+                <Button text="✕" onAction="#onClose" styleClass="icon-button close-button" />
+            </right>
+        </BorderPane>
+    </top>
+    <center>
+        <ListView fx:id="listView" />
+    </center>
+    <bottom>
+        <HBox spacing="8" alignment="CENTER_RIGHT" styleClass="bottom-bar">
+            <Button text="Refresh" onAction="#onRefresh" />
+        </HBox>
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Summary
- add `MonitorController` and new FXML to show processed text files
- add monitor page button in the main app
- document the new feature in README

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688627d94e20832d9a6bda9ed170ce55