### PR TITLE
Add splash screen and DMG packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>javafx-fxml</artifactId>
             <version>21</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -52,6 +58,24 @@
                 <configuration>
                     <mainClass>com.example.vostts.VosTtsApp</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.panteleyev</groupId>
+                <artifactId>jpackage-maven-plugin</artifactId>
+                <version>1.6.6</version>
+                <configuration>
+                    <input>${project.build.directory}</input>
+                    <destination>${project.build.directory}</destination>
+                    <mainClass>com.example.vostts.VosTtsApp</mainClass>
+                    <name>vos-stt</name>
+                    <type>dmg</type>
+                    <icon>${project.build.directory}/app-icon.png</icon>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -36,46 +36,52 @@ public class VosTtsApp extends Application {
 
         stage.initStyle(StageStyle.UNDECORATED);
 
+        // Splash screen while loading
+        FXMLLoader splashLoader = new FXMLLoader(getClass().getResource("/com/example/vostts/splash.fxml"));
+        Parent splashRoot = splashLoader.load();
+        ProgressBar bar = (ProgressBar) splashLoader.getNamespace().get("bar");
+        Label statusLabel = (Label) splashLoader.getNamespace().get("statusLabel");
+        Scene splashScene = new Scene(splashRoot, 400, 170);
+        ThemeManager.apply(splashScene);
+        Stage splashStage = new Stage(StageStyle.UNDECORATED);
+        splashStage.setTitle("Preparing Model");
+        splashStage.setScene(splashScene);
+        DragUtil.makeDraggable(splashStage, splashRoot);
+        splashStage.show();
+
+        Task<Void> task;
         if (VosTtsController.isModelValid(modelDir)) {
             LOG.info("Speech model found");
             controller.setModelReady(true);
+            task = new Task<>() {
+                @Override
+                protected Void call() throws Exception {
+                    updateProgress(1,1);
+                    Thread.sleep(2000);
+                    return null;
+                }
+            };
+        } else {
+            LOG.info("Speech model not present, downloading...");
+            statusLabel.setText("Downloading speech model...\nThis may take a few minutes.");
+            task = controller.createModelDownloadTask(modelDir);
+            bar.progressProperty().bind(task.progressProperty());
+            statusLabel.textProperty().bind(task.messageProperty());
+        }
+
+        task.setOnSucceeded(e -> {
+            controller.setModelDir(modelDir);
+            controller.setModelReady(true);
+            LOG.info("Speech model ready");
             Scene scene = new Scene(root, 400, 300);
             ThemeManager.apply(scene);
             DragUtil.makeDraggable(stage, root);
+            splashStage.close();
             stage.setScene(scene);
             stage.show();
-        } else {
-            LOG.info("Speech model not present, downloading...");
-            ProgressBar bar = new ProgressBar(0);
-            Label label = new Label("Downloading speech model...\nThis may take a few minutes.");
-            Label speedLabel = new Label();
-            VBox box = new VBox(10, label, bar, speedLabel);
-            box.setStyle("-fx-padding: 20; -fx-alignment: center;");
-            Scene splashScene = new Scene(box, 400, 170);
-            ThemeManager.apply(splashScene);
+        });
 
-            Stage splashStage = new Stage(StageStyle.UNDECORATED);
-            splashStage.setTitle("Preparing Model");
-            splashStage.setScene(splashScene);
-            DragUtil.makeDraggable(splashStage, box);
-            splashStage.show();
-
-            Task<Void> task = controller.createModelDownloadTask(modelDir);
-            bar.progressProperty().bind(task.progressProperty());
-            speedLabel.textProperty().bind(task.messageProperty());
-            task.setOnSucceeded(e -> {
-                controller.setModelDir(modelDir);
-                controller.setModelReady(true);
-                LOG.info("Speech model ready");
-                Scene scene = new Scene(root, 400, 300);
-                ThemeManager.apply(scene);
-                DragUtil.makeDraggable(stage, root);
-                splashStage.close();
-                stage.setScene(scene);
-                stage.show();
-            });
-            new Thread(task).start();
-        }
+        new Thread(task).start();
     }
 
     public static void main(String[] args) {

--- a/src/main/resources/com/example/vostts/browser.fxml
+++ b/src/main/resources/com/example/vostts/browser.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptionBrowserController">
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptionBrowserController" styleClass="root-pane">
     <top>
         <BorderPane styleClass="top-bar">
             <center>

--- a/src/main/resources/com/example/vostts/dark.css
+++ b/src/main/resources/com/example/vostts/dark.css
@@ -65,3 +65,14 @@
     -fx-text-fill: #888888;
     -fx-font-size: 20pt;
 }
+
+.splash-box {
+    -fx-background-radius: 10;
+    -fx-padding: 30;
+    -fx-alignment: center;
+    -fx-background-color: linear-gradient(from 0% 0% to 100% 100%, #ff4081, #7c4dff);
+}
+
+.splash-box .label {
+    -fx-text-fill: #EEEEEE;
+}

--- a/src/main/resources/com/example/vostts/light.css
+++ b/src/main/resources/com/example/vostts/light.css
@@ -61,3 +61,14 @@
     -fx-text-fill: #666666;
     -fx-font-size: 20pt;
 }
+
+.splash-box {
+    -fx-background-radius: 10;
+    -fx-padding: 30;
+    -fx-alignment: center;
+    -fx-background-color: linear-gradient(from 0% 0% to 100% 100%, #ff80ab, #b388ff);
+}
+
+.splash-box .label {
+    -fx-text-fill: #333333;
+}

--- a/src/main/resources/com/example/vostts/settings.fxml
+++ b/src/main/resources/com/example/vostts/settings.fxml
@@ -16,6 +16,6 @@
     </HBox>
     <HBox spacing="8" alignment="CENTER_RIGHT">
         <Button text="Save" onAction="#onSave" />
-        <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="close-button" />
+        <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="control-button close-button" />
     </HBox>
 </VBox>

--- a/src/main/resources/com/example/vostts/splash.fxml
+++ b/src/main/resources/com/example/vostts/splash.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" spacing="12" alignment="CENTER" styleClass="splash-box">
+    <Label text="vos-stt" styleClass="title" />
+    <ProgressBar fx:id="bar" prefWidth="260" />
+    <Label fx:id="statusLabel" />
+</VBox>

--- a/src/main/resources/com/example/vostts/viewer.fxml
+++ b/src/main/resources/com/example/vostts/viewer.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptViewerController">
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" fx:controller="com.example.vostts.TranscriptViewerController" styleClass="root-pane">
     <top>
         <BorderPane styleClass="top-bar">
             <center>
@@ -20,7 +20,7 @@
     </center>
     <bottom>
         <HBox alignment="CENTER_RIGHT" styleClass="bottom-bar">
-            <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="close-button" />
+            <Button fx:id="closeButton" text="Close" onAction="#onClose" styleClass="control-button close-button" />
         </HBox>
     </bottom>
 </BorderPane>

--- a/src/test/java/com/example/vostts/IconGeneratorTest.java
+++ b/src/test/java/com/example/vostts/IconGeneratorTest.java
@@ -1,0 +1,36 @@
+package com.example.vostts;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IconGeneratorTest {
+    @Test
+    void generateIconIfMissing() throws Exception {
+        Path icon = Path.of("target/app-icon.png");
+        if (Files.notExists(icon)) {
+            int size = 256;
+            BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g = img.createGraphics();
+            g.setPaint(new GradientPaint(0,0, Color.ORANGE, size, size, Color.BLUE));
+            g.fillRect(0,0,size,size);
+            g.setColor(Color.WHITE);
+            g.setFont(new Font("SansSerif", Font.BOLD, size/2));
+            FontMetrics fm = g.getFontMetrics();
+            String txt = "V";
+            int x = (size - fm.stringWidth(txt)) / 2;
+            int y = (size - fm.getHeight()) / 2 + fm.getAscent();
+            g.drawString(txt, x, y);
+            g.dispose();
+            Files.createDirectories(icon.getParent());
+            ImageIO.write(img, "png", icon.toFile());
+        }
+        assertTrue(Files.exists(icon));
+    }
+}


### PR DESCRIPTION
## Summary
- show a colorful splash while checking for model
- ensure UI components use theme classes
- generate close buttons with consistent styles
- support dark/light theme for splash
- add packaging plugin for mac dmg
- add unit test that creates app icon if missing

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_688627a26c5c832dac22824e18b77b89