### PR TITLE
Fix splash corners and simplify browser table

### DIFF
--- a/src/main/java/com/example/vostts/TranscriptionBrowserController.java
+++ b/src/main/java/com/example/vostts/TranscriptionBrowserController.java
@@ -29,8 +29,6 @@ public class TranscriptionBrowserController {
     @FXML private TableView<SessionMetadata> table;
     @FXML private TableColumn<SessionMetadata, String> nameColumn;
     @FXML private TableColumn<SessionMetadata, String> dateColumn;
-    @FXML private TableColumn<SessionMetadata, String> durationColumn;
-    @FXML private TableColumn<SessionMetadata, String> statusColumn;
 
     private final ObservableList<SessionMetadata> sessions = FXCollections.observableArrayList();
 
@@ -38,8 +36,6 @@ public class TranscriptionBrowserController {
     private void initialize() {
         nameColumn.setCellValueFactory(new PropertyValueFactory<>("name"));
         dateColumn.setCellValueFactory(new PropertyValueFactory<>("date"));
-        durationColumn.setCellValueFactory(new PropertyValueFactory<>("duration"));
-        statusColumn.setCellValueFactory(new PropertyValueFactory<>("status"));
         table.setItems(sessions);
         refresh();
     }

--- a/src/main/resources/com/example/vostts/browser.fxml
+++ b/src/main/resources/com/example/vostts/browser.fxml
@@ -17,8 +17,6 @@
             <columns>
                 <TableColumn fx:id="nameColumn" text="Name" prefWidth="200" />
                 <TableColumn fx:id="dateColumn" text="Date" prefWidth="180" />
-                <TableColumn fx:id="durationColumn" text="Duration" prefWidth="120" />
-                <TableColumn fx:id="statusColumn" text="Status" prefWidth="120" />
             </columns>
         </TableView>
     </center>

--- a/src/main/resources/com/example/vostts/dark.css
+++ b/src/main/resources/com/example/vostts/dark.css
@@ -77,7 +77,7 @@
 }
 
 .splash-box {
-    -fx-background-radius: 10;
+    -fx-background-radius: 0;
     -fx-padding: 30;
     -fx-alignment: center;
     -fx-background-color: linear-gradient(from 0% 0% to 100% 100%, #ff4081, #7c4dff);

--- a/src/main/resources/com/example/vostts/light.css
+++ b/src/main/resources/com/example/vostts/light.css
@@ -63,7 +63,7 @@
 }
 
 .splash-box {
-    -fx-background-radius: 10;
+    -fx-background-radius: 0;
     -fx-padding: 30;
     -fx-alignment: center;
     -fx-background-color: linear-gradient(from 0% 0% to 100% 100%, #ff80ab, #b388ff);


### PR DESCRIPTION
## Summary
- square off splash screen corners in light and dark themes
- remove duration and status columns from the transcription browser

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688681ba33a0832db6de8b542a61e158