### PR TITLE
Fix jpackage packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
                     <input>${project.build.directory}</input>
                     <destination>${project.build.directory}</destination>
                     <mainClass>com.example.vostts.VosTtsApp</mainClass>
+                    <mainJar>${project.build.finalName}.jar</mainJar>
                     <name>vos-stt</name>
                     <!-- Image type must match enum constants defined by the
                          jpackage plugin and is case sensitive -->


### PR DESCRIPTION
## Summary
- configure the jpackage-maven-plugin with a main jar to fix the build error

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_6886936c0314832db48c9794dd33c8e0