### PR TITLE
Improve transcript handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ running the application.
 
 Click **Start Live Transcription** to begin a session. Lines of text will
 appear in large font as the mock recogniser generates them. While a session is
-running the subtitle file `transcript.srt` is written to the application
-directory. Once the session ends the file is moved into a session folder under
-your home directory with timestamps for every recognised phrase.
+running the subtitle file `transcript.tmp` is written under
+`~/Transcriptions/<today>/<session>`. When the session ends the file is renamed
+to `transcript.srt` with timestamps for every recognised phrase.
 
 Use **🗂 Browse Sessions** to open the new Transcription Browser. From there you
 can open previous transcripts in a modal viewer or remove old sessions.
@@ -41,3 +41,4 @@ mvn test package
 ```
 
 The resulting `vos-stt.dmg` can be found in the `target` directory.
+**Note:** DMG packaging is currently broken.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>vos-tts</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1</version>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/src/main/java/com/example/vostts/TranscriptionBrowserController.java
+++ b/src/main/java/com/example/vostts/TranscriptionBrowserController.java
@@ -47,11 +47,13 @@ public class TranscriptionBrowserController {
 
     private void refresh() {
         sessions.clear();
-        Path base = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions");
+        Path base = Paths.get(System.getProperty("user.home"), "Transcriptions");
         if (Files.isDirectory(base)) {
             try {
-                List<SessionMetadata> list = Files.list(base)
+                List<SessionMetadata> list = Files.walk(base, 2)
+                        .filter(p -> !p.equals(base))
                         .filter(Files::isDirectory)
+                        .filter(p -> p.getParent() != null && !p.getParent().equals(base))
                         .map(p -> {
                             try {
                                 return SessionMetadata.load(p);

--- a/src/main/java/com/example/vostts/VosTtsApp.java
+++ b/src/main/java/com/example/vostts/VosTtsApp.java
@@ -17,6 +17,13 @@ import com.example.vostts.DragUtil;
 
 import com.example.logging.LoggingConfig;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.stream.Stream;
+
 import java.util.logging.Logger;
 
 import java.io.File;
@@ -26,6 +33,7 @@ public class VosTtsApp extends Application {
 
     @Override
     public void start(Stage stage) throws Exception {
+        cleanupTempTranscripts();
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/example/vostts/app.fxml"));
         Parent root = loader.load();
         VosTtsController controller = loader.getController();
@@ -88,5 +96,28 @@ public class VosTtsApp extends Application {
         LoggingConfig.configure();
         LOG.info("Launching application");
         launch(args);
+    }
+
+    /**
+     * Scan the default transcription directory for any leftover temporary files
+     * and rename them to {@code .srt} so crashed sessions are recovered.
+     */
+    private void cleanupTempTranscripts() {
+        Path base = Paths.get(System.getProperty("user.home"), "Transcriptions");
+        if (!Files.isDirectory(base)) {
+            return;
+        }
+        try (Stream<Path> stream = Files.walk(base)) {
+            stream.filter(p -> p.toString().endsWith(".tmp")).forEach(p -> {
+                try {
+                    Files.move(p, p.resolveSibling(p.getFileName().toString().replaceFirst("\\.tmp$", ".srt")),
+                               StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    LOG.log(java.util.logging.Level.WARNING, "Failed to rename temp file " + p, e);
+                }
+            });
+        } catch (IOException e) {
+            LOG.log(java.util.logging.Level.WARNING, "Failed to scan for temp files", e);
+        }
     }
 }

--- a/src/main/java/com/example/vostts/VosTtsController.java
+++ b/src/main/java/com/example/vostts/VosTtsController.java
@@ -33,6 +33,7 @@ import java.nio.file.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -310,11 +311,17 @@ public class VosTtsController {
     }
 
     private void runRecognition() {
-        Path sessionDir = Paths.get(System.getProperty("user.home"), "vos-stt", "sessions", currentSessionId);
-        File activeFile = new File("transcript.srt");
-        LOG.fine(() -> "Writing transcript to " + activeFile.getAbsolutePath());
+        Path sessionDir = Paths.get(System.getProperty("user.home"), "Transcriptions",
+                java.time.LocalDate.now().toString(), currentSessionId);
+        Path tmpFile = sessionDir.resolve("transcript.tmp");
+        try {
+            Files.createDirectories(sessionDir);
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE, "Failed to create session directory", e);
+        }
+        LOG.fine(() -> "Writing transcript to " + tmpFile.toAbsolutePath());
         try (Model model = new Model(locateModelPath(modelDir).getAbsolutePath());
-             BufferedWriter bw = new BufferedWriter(new FileWriter(activeFile))) {
+             BufferedWriter bw = Files.newBufferedWriter(tmpFile)) {
             writer = bw;
             Recognizer recognizer = new Recognizer(model, 16000.0f);
             AudioFormat format = new AudioFormat(16000.0f, 16, 1, true, false);
@@ -360,10 +367,9 @@ public class VosTtsController {
                     settingsButton.setDisable(false);
                 }
             });
-            // Move the transcript to the session directory when finished
+            // Rename the temporary transcript once the session ends
             try {
-                sessionDir.toFile().mkdirs();
-                Files.move(activeFile.toPath(), sessionDir.resolve("transcript.srt"),
+                Files.move(tmpFile, sessionDir.resolve("transcript.srt"),
                         StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e) {
                 LOG.log(Level.SEVERE, "Failed to store session transcript", e);


### PR DESCRIPTION
## Summary
- update Maven project version to **0.1**
- mention that DMG packaging is broken
- persist daily transcription sessions under `~/Transcriptions` and rename tmp files when finished
- clean up leftover temporary transcripts on start
- update session browser to read new location

## Testing
- `mvn -q test` *(fails: Could not resolve plugin)*
- `mvn -q -DskipTests compile` *(fails: Could not resolve plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6886fd77c810832da955ae8e20144d7a